### PR TITLE
added ability to pass root_key or define root_key on the resource

### DIFF
--- a/lib/rails_util/json_helper.rb
+++ b/lib/rails_util/json_helper.rb
@@ -3,13 +3,14 @@ module RailsUtil
 
     def json_with(resource, **options)
       return json_empty(**options) unless resource
+      root_key = options.fetch(:root_key, fetch_key_from_resource(resource))
 
       return json_error({
-        resource.class.name.underscore => map_base_to__error(resource.errors.messages)
+        root_key => map_base_to__error(resource.errors.messages)
       }, **options) if has_errors?(resource)
 
       return json_success({
-        resource.class.name.underscore => Hash.new
+        root_key => Hash.new
       }, **options) if is_destroyed?(resource)
 
       render json: resource, **options
@@ -36,6 +37,11 @@ module RailsUtil
     end
 
     private
+
+    def fetch_key_from_resource(resource)
+      return resource.root_key if resource.respond_to?(:root_key)
+      resource.class.name.underscore
+    end
 
     def set_nested_path(nested_path_or_obj, message)
       return RailsUtil::Util.set_nested(nested_path_or_obj, message) if nested_path_or_obj.is_a? String


### PR DESCRIPTION
In order for the form objects idea to work (see [here](https://revs.runtime-revolution.com/saving-multiple-models-with-form-objects-and-transactions-2c26f37f7b9a)), we need to ensure the object returns the right path for non activerecord classes. 

For example, if we have a `CreateUser` form object class, we may want the error response to use the key `user` instead of `create_user`:

```json
{ 
  "user": { 
    "first_name": ["can't be blank"]
  }
}
```

This PR allows the root_key to be passed as an option or the user can simply define an instance method `root_key` on the resource class.

So, in our `CreateUser` case, we could do:

```ruby
class CreateUser
  def root_key
    'user'
  end
end
```
@rkillackey are you in the process of writing tests for `json_helper`? I saw you self-assigned that issue. I took 30 minutes and attempted to do this and realized it's a little difficult to test due to coupling with Rails controller. Will need to think through how we should setup the test suite here - perhaps @davemcorwin can provide some insight.